### PR TITLE
Inject customer resource model as proxy into command class

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="GhoSter\ChangeCustomerPassword\Command\CustomerChangePasswordCommand">
+        <arguments>
+            <argument name="resource" xsi:type="object">Magento\Customer\Model\ResourceModel\Customer\Proxy</argument>
+        </arguments>
+    </type>
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
Installing a fresh Magento instance with package code installed fails.

Steps to reproduce:

* `composer create-project magento/project-community-edition [args]`
* `composer require ghoster/changecustomerpassword`
* `./bin/magento setup:install [args]`
* Expected: Installation finishes with no error
* Actual: `Base table or view not found: 1146 Table 'eav_entity_type' doesn't exist`

When executing `bin/magento setup:install`, then Magento instantiates all the registered Symfony console commands early in the process. At this point in time, the database tables are not yet created. Therefore, if any resource models are instantiated in the tree of object dependencies, then the installation crashes. In order to prevent that "chain reaction of object instantiation" and enable lazy-loading, such dependencies must be injected as proxies. With this change, the `Customer` resource model that gets injected into the `CustomerChangePasswordCommand` will only be instantiated when the command is actually triggered, but no longer on Magento installation.