### PR TITLE
Do not validate customer object on save

### DIFF
--- a/Controller/Adminhtml/Password/ChangePwdPost.php
+++ b/Controller/Adminhtml/Password/ChangePwdPost.php
@@ -58,9 +58,7 @@ class ChangePwdPost extends Action implements HttpPostActionInterface
         $this->customerRepository = $customerRepository;
         $this->customerRegistry = $customerRegistry;
         $this->encryptor = $encryptor;
-        $objectManager = ObjectManager::getInstance();
-        $this->addressRegistry = $addressRegistry
-            ?: $objectManager->get(AddressRegistry::class);
+        $this->addressRegistry = $addressRegistry ?: ObjectManager::getInstance()->get(AddressRegistry::class);
         parent::__construct($context);
     }
 

--- a/Controller/Adminhtml/Password/ChangePwdPost.php
+++ b/Controller/Adminhtml/Password/ChangePwdPost.php
@@ -11,6 +11,8 @@ use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Model\CustomerRegistry;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Customer\Model\AddressRegistry;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Class ChangePwdPost for password changing
@@ -33,22 +35,32 @@ class ChangePwdPost extends Action implements HttpPostActionInterface
     protected $encryptor;
 
     /**
+     * @var AddressRegistry
+     */
+    private $addressRegistry;
+
+    /**
      * ChangePwdPost constructor.
      *
      * @param Context $context
      * @param CustomerRepositoryInterface $customerRepository
      * @param CustomerRegistry $customerRegistry
      * @param EncryptorInterface $encryptor
+     * @param AddressRegistry|null $addressRegistry
      */
     public function __construct(
         Context $context,
         CustomerRepositoryInterface $customerRepository,
         CustomerRegistry $customerRegistry,
-        EncryptorInterface $encryptor
+        EncryptorInterface $encryptor,
+        ?AddressRegistry $addressRegistry = null
     ) {
         $this->customerRepository = $customerRepository;
         $this->customerRegistry = $customerRegistry;
         $this->encryptor = $encryptor;
+        $objectManager = ObjectManager::getInstance();
+        $this->addressRegistry = $addressRegistry
+            ?: $objectManager->get(AddressRegistry::class);
         parent::__construct($context);
     }
 
@@ -74,6 +86,11 @@ class ChangePwdPost extends Action implements HttpPostActionInterface
                     $customerSecureRegistry->setRpToken(null);
                     $customerSecureRegistry->setRpTokenCreatedAt(null);
                     $customerSecureRegistry->setPasswordHash($this->createPasswordHash($password));
+
+                    // No need to validate customer and customer address while saving customer reset password token
+                    $this->disableAddressValidation($customer);
+                    $this->setIgnoreValidationFlag($customer);
+
                     $this->customerRepository->save($customer, $this->createPasswordHash($password));
                     $this->messageManager->addSuccessMessage(__('Password has been updated successfully.'));
                 }
@@ -86,6 +103,31 @@ class ChangePwdPost extends Action implements HttpPostActionInterface
         }
 
         return $resultRedirect->setPath('*/*/');
+    }
+
+    /**
+     * Disable Customer Address Validation
+     *
+     * @param CustomerInterface $customer
+     * @throws NoSuchEntityException
+     */
+    private function disableAddressValidation($customer)
+    {
+        foreach ($customer->getAddresses() as $address) {
+            $addressModel = $this->addressRegistry->retrieve($address->getId());
+            $addressModel->setShouldIgnoreValidation(true);
+        }
+    }
+
+    /**
+     * Set ignore_validation_flag for reset password flow to skip unnecessary address and customer validation
+     *
+     * @param Customer $customer
+     * @return void
+     */
+    private function setIgnoreValidationFlag($customer)
+    {
+        $customer->setData('ignore_validation_flag', true);
     }
 
     /**


### PR DESCRIPTION
Do not validate customer object when saving new password, like magento's resetPassword method also does

Fixes #23 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the password reset process to streamline account recovery by bypassing address validation, ensuring a smoother and more reliable experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->