### PR TITLE
Added separate ACL Resource for change password action

### DIFF
--- a/Controller/Adminhtml/Password/ChangePwdPost.php
+++ b/Controller/Adminhtml/Password/ChangePwdPost.php
@@ -19,6 +19,8 @@ use Magento\Framework\App\ObjectManager;
  */
 class ChangePwdPost extends Action implements HttpPostActionInterface
 {
+    public const ADMIN_RESOURCE = 'GhoSter_ChangeCustomerPassword::change_password';
+
     /**
      * @var CustomerRepositoryInterface
      */
@@ -137,13 +139,5 @@ class ChangePwdPost extends Action implements HttpPostActionInterface
     protected function createPasswordHash(string $password)
     {
         return $this->encryptor->getHash($password, true);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Magento_Customer::manage');
     }
 }

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Customer::customer">
+                    <resource id="Magento_Customer::manage">
+                        <resource id="Magento_Customer::actions">
+                            <resource id="GhoSter_ChangeCustomerPassword::change_password"
+                                      title="Change password"
+                                      sortOrder="25"/>
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/view/adminhtml/layout/customer_index_edit.xml
+++ b/view/adminhtml/layout/customer_index_edit.xml
@@ -5,6 +5,7 @@
         <referenceContainer name="content">
             <block class="GhoSter\ChangeCustomerPassword\Block\Adminhtml\Customer\PasswordChange"
                    name="customer_change_password"
+                   aclResource="GhoSter_ChangeCustomerPassword::change_password"
                    template="GhoSter_ChangeCustomerPassword::customer/password_change.phtml"/>
         </referenceContainer>
     </body>


### PR DESCRIPTION
**Summary**

- Add ACL resource `GhoSter_ChangeCustomerPassword::change_password` to control access to the change customer password functionality
- Protect admin controller with `ADMIN_RESOURCE` constant
- Hide password change block for unauthorized users using `aclResource` attribute in layout XML

**Details**

The new ACL permission is placed under `Magento_Customer::actions` alongside existing customer action permissions:
- Customers → All Customers → Actions → Change password

<img width="2434" height="1586" alt="image" src="https://github.com/user-attachments/assets/03e8578d-48d3-4ac7-b5ca-7839f4b851f4" />

This allows administrators to grant or revoke the ability to change customer passwords independently from other customer management permissions.

**Changes**

  - `etc/acl.xml` - New ACL resource definition
  - `Controller/Adminhtml/Password/ChangePwdPost.php` - Added `ADMIN_RESOURCE` constant
  - `view/adminhtml/layout/customer_index_edit.xml` - Added `aclResource` attribute to block

**Reference**

Similar to Magento core reset password ACL implementation:
- https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Customer/etc/acl.xml#L16
- https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Customer/Controller/Adminhtml/Index/ResetPassword.php#L24






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Implemented dedicated access control for customer password changes, providing administrators with more granular permission management instead of requiring broad customer management rights.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->