### PR TITLE
Password Validation for Admin Customer Password Change

### DIFF
--- a/Block/Adminhtml/Customer/PasswordChange.php
+++ b/Block/Adminhtml/Customer/PasswordChange.php
@@ -3,13 +3,36 @@ declare(strict_types=1);
 
 namespace GhoSter\ChangeCustomerPassword\Block\Adminhtml\Customer;
 
+use GhoSter\ChangeCustomerPassword\Model\Config;
 use Magento\Backend\Block\Template;
+use Magento\Backend\Block\Template\Context;
 
 /**
  * Class PasswordChange for block
  */
 class PasswordChange extends Template
 {
+    /**
+     * @var Config
+     */
+    private $passwordConfig;
+
+    /**
+     * PasswordChange constructor.
+     *
+     * @param Context $context
+     * @param Config $passwordConfig
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        Config $passwordConfig,
+        array $data = []
+    ) {
+        $this->passwordConfig = $passwordConfig;
+        parent::__construct($context, $data);
+    }
+
     /**
      * Get current customer id
      *
@@ -18,5 +41,25 @@ class PasswordChange extends Template
     public function getCustomerId(): int
     {
         return (int)$this->getRequest()->getParam('id');
+    }
+
+    /**
+     * Get minimum password length from config
+     *
+     * @return int
+     */
+    public function getMinimumPasswordLength(): int
+    {
+        return $this->passwordConfig->getMinimumPasswordLength();
+    }
+
+    /**
+     * Get required number of character classes from config
+     *
+     * @return int
+     */
+    public function getRequiredCharacterClassesNumber(): int
+    {
+        return $this->passwordConfig->getRequiredCharacterClassesNumber();
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -37,7 +37,8 @@ class Config
     public function getMinimumPasswordLength(): int
     {
         return (int)$this->scopeConfig->getValue(
-            self::XML_PATH_MINIMUM_PASSWORD_LENGTH, ScopeInterface::SCOPE_STORE
+            self::XML_PATH_MINIMUM_PASSWORD_LENGTH,
+            ScopeInterface::SCOPE_STORE
         ) ?: self::DEFAULT_MINIMUM_PASSWORD_LENGTH;
     }
 

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace GhoSter\ChangeCustomerPassword\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class Config
+{
+    private const XML_PATH_MINIMUM_PASSWORD_LENGTH = 'customer/password/minimum_password_length';
+    private const XML_PATH_REQUIRED_CHARACTER_CLASSES_NUMBER = 'customer/password/required_character_classes_number';
+    private const DEFAULT_MINIMUM_PASSWORD_LENGTH = 8;
+    private const DEFAULT_REQUIRED_CHARACTER_CLASSES = 3;
+    private const MAX_PASSWORD_LENGTH = 256;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * Config constructor.
+     *
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(ScopeConfigInterface $scopeConfig)
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Get minimum password length
+     *
+     * @return int
+     */
+    public function getMinimumPasswordLength(): int
+    {
+        return (int)$this->scopeConfig->getValue(
+            self::XML_PATH_MINIMUM_PASSWORD_LENGTH, ScopeInterface::SCOPE_STORE
+        ) ?: self::DEFAULT_MINIMUM_PASSWORD_LENGTH;
+    }
+
+    /**
+     * Get maximum password length
+     *
+     * @return int
+     */
+    public function getMaximumPasswordLength(): int
+    {
+        return self::MAX_PASSWORD_LENGTH;
+    }
+
+    /**
+     * Get required character classes number
+     *
+     * @return int
+     */
+    public function getRequiredCharacterClassesNumber(): int
+    {
+        return (int)$this->scopeConfig->getValue(
+            self::XML_PATH_REQUIRED_CHARACTER_CLASSES_NUMBER,
+            ScopeInterface::SCOPE_STORE
+        ) ?: self::DEFAULT_REQUIRED_CHARACTER_CLASSES;
+    }
+}

--- a/Model/PasswordValidator.php
+++ b/Model/PasswordValidator.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GhoSter\ChangeCustomerPassword\Model;
+
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Stdlib\StringUtils;
+
+class PasswordValidator
+{
+    /**
+     * @var Config
+     */
+    private $passwordConfig;
+
+    /**
+     * @var StringUtils
+     */
+    private $stringHelper;
+
+    /**
+     * PasswordValidator constructor.
+     *
+     * @param Config $passwordConfig
+     * @param StringUtils $stringHelper
+     */
+    public function __construct(Config $passwordConfig, StringUtils $stringHelper)
+    {
+        $this->passwordConfig = $passwordConfig;
+        $this->stringHelper = $stringHelper;
+    }
+
+    /**
+     * Validate password
+     *
+     * @param string $password
+     *
+     * @return void
+     * @throws InputException
+     */
+    public function validate(string $password)
+    {
+        $this->validateLength($password);
+        $this->validateWhitespace($password);
+        $this->validateCharacterClasses($password);
+    }
+
+    /**
+     * Validate password length
+     *
+     * @param string $password
+     *
+     * @return void
+     * @throws InputException
+     */
+    private function validateLength(string $password)
+    {
+        $minLength = $this->passwordConfig->getMinimumPasswordLength();
+        if ($this->stringHelper->strlen($password) < $minLength) {
+            throw new InputException(
+                __(
+                    'The password needs at least %1 characters. Create a new password and try again.',
+                    $minLength
+                )
+            );
+        }
+
+        $maxLength = $this->passwordConfig->getMaximumPasswordLength();
+        if ($this->stringHelper->strlen($password) > $maxLength) {
+            throw new InputException(
+                __(
+                    'Please enter a password with at most %1 characters.',
+                    $maxLength
+                )
+            );
+        }
+    }
+
+    /**
+     * Validate password trailing and leading whitespace
+     *
+     * @param string $password
+     *
+     * @return void
+     * @throws InputException
+     */
+    private function validateWhitespace(string $password)
+    {
+        if ($password !== trim($password)) {
+            throw new InputException(
+                __("The password can't begin or end with a space. Verify the password and try again.")
+            );
+        }
+    }
+
+    /**
+     * Validate password character classes
+     *
+     * @param string $password
+     *
+     * @return void
+     * @throws InputException
+     */
+    private function validateCharacterClasses(string $password)
+    {
+        $requiredCharClassesNumber = $this->passwordConfig->getRequiredCharacterClassesNumber();
+        $characterClassesCount = 0;
+
+        if (preg_match('/\d+/', $password)) {
+            $characterClassesCount++;
+        }
+
+        if (preg_match('/[a-z]+/', $password)) {
+            $characterClassesCount++;
+        }
+
+        if (preg_match('/[A-Z]+/', $password)) {
+            $characterClassesCount++;
+        }
+
+        if (preg_match('/[^a-zA-Z0-9]+/', $password)) {
+            $characterClassesCount++;
+        }
+
+        if ($characterClassesCount < $requiredCharClassesNumber) {
+            throw new InputException(
+                __(
+                    'Minimum of different classes of characters in password is %1.'
+                    . ' Classes of characters: Lower Case, Upper Case, Digits, Special Characters.',
+                    $requiredCharClassesNumber
+                )
+            );
+        }
+    }
+}

--- a/view/adminhtml/templates/customer/password_change.phtml
+++ b/view/adminhtml/templates/customer/password_change.phtml
@@ -24,7 +24,9 @@
                            aria-label="<?= $block->escapeHtml(__('Password')) ?>"
                            name="new_customer_pwd"
                            data-password-min-length="<?= $block->escapeHtmlAttr($block->getMinimumPasswordLength()) ?>"
-                           data-password-min-character-sets="<?= $block->escapeHtmlAttr($block->getRequiredCharacterClassesNumber()) ?>"
+                           data-password-min-character-sets="<?= $block->escapeHtmlAttr(
+                                   $block->getRequiredCharacterClassesNumber()
+                           ) ?>"
                            data-validate="{required:true, 'validate-customer-password':true}"
                            autocomplete="off"
                            title="<?= $block->escapeHtml(__('Password')) ?>"

--- a/view/adminhtml/templates/customer/password_change.phtml
+++ b/view/adminhtml/templates/customer/password_change.phtml
@@ -24,9 +24,7 @@
                            aria-label="<?= $block->escapeHtml(__('Password')) ?>"
                            name="new_customer_pwd"
                            data-password-min-length="<?= $block->escapeHtmlAttr($block->getMinimumPasswordLength()) ?>"
-                           data-password-min-character-sets="<?= $block->escapeHtmlAttr(
-                                   $block->getRequiredCharacterClassesNumber()
-                           ) ?>"
+                           data-password-min-character-sets="<?= $block->escapeHtmlAttr($block->getRequiredCharacterClassesNumber()) ?>"
                            data-validate="{required:true, 'validate-customer-password':true}"
                            autocomplete="off"
                            title="<?= $block->escapeHtml(__('Password')) ?>"

--- a/view/adminhtml/templates/customer/password_change.phtml
+++ b/view/adminhtml/templates/customer/password_change.phtml
@@ -10,24 +10,29 @@
 
     <div class="admin__fieldset-wrapper-content">
         <form action="<?= $block->escapeUrl($block->getUrl('customer/password/changePwdPost')); ?>"
-              method="post">
+              method="post"
+              data-mage-init='{"validation": {}}'>
             <?= $block->getBlockHtml('formkey') ?>
         <input id="customer_id" type="hidden" name="customer_id" value="<?= $block->escapeHtml($customerId); ?>" />
-            <div class="admin__field">
+            <div class="admin__field admin__field-medium">
                 <label class="admin__field-label">
                     <span><?= /* @escapeNotVerified */ $block->escapeHtml(__('Enter Password')); ?></span>
                 </label>
-            </div>
-            <div class="admin__field-control">
-                <input class="admin__control-text"
-                       type="password"
-                       aria-label="<?= $block->escapeHtml(__('Password')) ?>"
-                       name="new_customer_pwd"
-                       style="width: 48%"
-                       title="">
+                <div class="admin__field-control">
+                    <input class="admin__control-text"
+                           type="password"
+                           aria-label="<?= $block->escapeHtml(__('Password')) ?>"
+                           name="new_customer_pwd"
+                           data-password-min-length="<?= $block->escapeHtmlAttr($block->getMinimumPasswordLength()) ?>"
+                           data-password-min-character-sets="<?= $block->escapeHtmlAttr($block->getRequiredCharacterClassesNumber()) ?>"
+                           data-validate="{required:true, 'validate-customer-password':true}"
+                           autocomplete="off"
+                           title="<?= $block->escapeHtml(__('Password')) ?>"
+                           placeholder="<?= $block->escapeHtml(__('Password')) ?>">
+                </div>
             </div>
 
-            <div class="admin__field-control action">
+            <div class="admin__field admin__field-control action">
                 <button id="save"
                         title="<?= $block->escapeHtml(__('Save Customer')) ?>"
                         type="submit"

--- a/view/adminhtml/templates/customer/password_change.phtml
+++ b/view/adminhtml/templates/customer/password_change.phtml
@@ -24,7 +24,9 @@
                            aria-label="<?= $block->escapeHtml(__('Password')) ?>"
                            name="new_customer_pwd"
                            data-password-min-length="<?= $block->escapeHtmlAttr($block->getMinimumPasswordLength()) ?>"
-                           data-password-min-character-sets="<?= $block->escapeHtmlAttr($block->getRequiredCharacterClassesNumber()) ?>"
+                           data-password-min-character-sets="<?= $block->escapeHtmlAttr(
+                               $block->getRequiredCharacterClassesNumber()
+                           ) ?>"
                            data-validate="{required:true, 'validate-customer-password':true}"
                            autocomplete="off"
                            title="<?= $block->escapeHtml(__('Password')) ?>"
@@ -34,7 +36,7 @@
 
             <div class="admin__field admin__field-control action">
                 <button id="save"
-                        title="<?= $block->escapeHtml(__('Save Customer')) ?>"
+                        title="<?= $block->escapeHtml(__('Update Password')) ?>"
                         type="submit"
                         class="action-scalable
                         save primary ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only"


### PR DESCRIPTION
## Problem

The original module allows admins to set any password for a customer without validation.
This bypasses the password strength rules enforced on the storefront, leading to inconsistent security policies.

## Solution

Added password validation that matches Magento core behavior for both backend (PHP) and frontend (JavaScript).

### Backend Validation

Password is validated before saving using the same rules as:
- `Magento\Customer\Model\AccountManagement::checkPasswordStrength()` (protected method, lines [L747-L784](https://github.com/magento/magento2/blob/2.4.8-p3/app/code/Magento/Customer/Model/AccountManagement.php#L747-L784))
- `Magento\Customer\Model\AccountManagement::makeRequiredCharactersCheck()` (protected method, lines [L792-L818](https://github.com/magento/magento2/blob/2.4.8-p3/app/code/Magento/Customer/Model/AccountManagement.php#L792-L818))

Validation rules:
- Minimum password length (from `customer/password/minimum_password_length` config, default: 8)
- Maximum password length (256 characters, matching `Magento\Customer\Api\AccountManagementInterface::MAX_PASSWORD_LENGTH`)
- No leading or trailing whitespace
- Required character classes count (from `customer/password/required_character_classes_number` config, default: 3 of 4: lowercase, uppercase, digits, special characters)

Uses `Magento\Framework\Stdlib\StringUtils::strlen()` for multibyte-safe length checks.

### Frontend Validation

Uses Magento's built-in `validate-customer-password` validator from `mage/validation.js`,
the same validator used on the storefront registration form:
- `vendor/magento/module-customer/view/frontend/templates/form/register.phtml` (lines [L257-L262](https://github.com/magento/magento2/blob/2.4.8-p3/app/code/Magento/Customer/view/frontend/templates/form/register.phtml#L257-L262))

The password input includes `data-password-min-length` and `data-password-min-character-sets`
data attributes read from store config, matching the frontend registration form approach.

## Files Changed

| File | Change |
|---|---|
| `Block/Adminhtml/Customer/PasswordChange.php` | Added `Config` dependency, `getMinimumPasswordLength()` and `getRequiredCharacterClassesNumber()` methods |
| `Controller/Adminhtml/Password/ChangePwdPost.php` | Added `PasswordValidator` dependency, calls `validate()` before save |
| `view/adminhtml/templates/customer/password_change.phtml` | Added `data-validate`, `data-password-min-length`, `data-password-min-character-sets` attributes |

## Files Added

| File | Purpose |
|---|---|
| `Model/Config.php` | Reads password policy settings from Magento store config |
| `Model/PasswordValidator.php` | Validates password strength (length, whitespace, character classes) |

## Compatibility

PHP 7.3+ (no typed properties used).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces configurable password policy (min/max length, required character classes) with clear validation errors.
  * Adds server-side and client-side password validation (length, whitespace, character-class diversity).
  * Enhanced admin password change form with validation hints, data-driven attributes, improved layout, and updated button label.

* **Refactor**
  * Centralized password policy and validation logic and exposed policy values to the admin form for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->